### PR TITLE
Build Vite with Base Path

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
           cache: "npm"
       - uses: actions/configure-pages@v5
       - run: npm ci
-      - run: npm run build
+      - run: npm run build:pages
       - uses: actions/upload-pages-artifact@v4
         with:
           path: app/dist

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "ERC-7955: Permissionless CREATE2 Factory",
   "type": "module",
   "scripts": {
-    "build": "hardhat compile && tsc -b && vite build",
+    "build": "hardhat compile && tsc -b",
+    "build:pages": "vite build --base=/erc-7955/",
     "lint": "biome check",
     "start": "vite",
     "test": "hardhat test nodejs"


### PR DESCRIPTION
Serving Vite apps on GitHub pages requires them to be built with a base path. This PR adds that in.