### PR TITLE
Increase Grace Period Post-Transaction Confirmation

### DIFF
--- a/app/components/TransactionButton.tsx
+++ b/app/components/TransactionButton.tsx
@@ -75,7 +75,7 @@ function TransactionButton({
         // This gives feedback to the user that the transaction succeeded, while
         // preventing the transaction button from "flashing" back to enabled in
         // the time it takes for block chain state to propagate through the app.
-        setTimeout(() => setHash(null), 2000);
+        setTimeout(() => setHash(null), 15000);
       } else {
         setHash(null);
         setReverted(false);

--- a/app/hooks/useBurnerMissingFunds.ts
+++ b/app/hooks/useBurnerMissingFunds.ts
@@ -49,7 +49,6 @@ function useBurnerMissingFunds({
       return { balance, missingFunds };
     },
     enabled: !!client,
-    staleTime: 1000,
     refetchInterval: 1000,
   });
 }


### PR DESCRIPTION
This PR increases the grace period after confirming a transaction. During testing, @tschubotz found that for some chains, the `Deploy` button would become enabled again, which could cause some issues as the user would try to deploy the factory a second time (which would result in an error).

Although, I can't reproduce it locally, my intuition is that the stale empty bytecode for the permissionless CREATE2 factory that is used to determin the state of the deployment wizard takes longer to refresh in some situations. The solution is to increase the "grace period" on the transaction button (so the button's "confirmed" state lingers for longer) and remove the "stale time" setting on one of our queries related to the current app state - making it so requeries always refetch data instead of reusing a, potentially stale, cache.