### PR TITLE
Add EIP-7702 Check

### DIFF
--- a/app/components/Deploy.tsx
+++ b/app/components/Deploy.tsx
@@ -1,5 +1,6 @@
 import {
   Alert,
+  Button,
   Card,
   Center,
   Code,
@@ -25,6 +26,7 @@ import { useBootstrapContract } from "@/hooks/useBootstrapContract.ts";
 import { useBurnerMissingFunds } from "@/hooks/useBurnerMissingFunds.ts";
 import { useDeployFactoryTransaction } from "@/hooks/useDeployFactoryTransaction.ts";
 import { useFactoryDeployed } from "@/hooks/useFactoryDeployed.ts";
+import { useSupports7702 } from "@/hooks/useSupports7702.ts";
 
 function DeployBootstrap({
   onDeployed,
@@ -201,13 +203,19 @@ function Deploy() {
 }
 
 function Connected() {
+  const support = useSupports7702();
+  const [dismiss7702Check, setDismiss7702Check] = useState(false);
+
   const bootstrap = useBootstrapContract();
   const transaction = useDeployFactoryTransaction({ bootstrap });
   const funding = useBurnerMissingFunds({ transaction });
   const factory = useFactoryDeployed();
 
   const isPending =
-    bootstrap.isLoading || funding.isLoading || factory.isPending;
+    support.isLoading ||
+    bootstrap.isLoading ||
+    funding.isLoading ||
+    factory.isPending;
   const active = factory.data
     ? 3
     : funding.data?.missingFunds === 0n
@@ -227,6 +235,20 @@ function Connected() {
     <Center>
       <Loader />
     </Center>
+  ) : support.data !== true && !dismiss7702Check ? (
+    <Alert icon={"⚠"} title="Error" color="red">
+      <Stack>
+        <Text size="sm">
+          The connected network does not appear to support EIP-7702, the
+          ERC-7955 permissionless CREATE2 factory deployment is likely to fail.
+        </Text>
+        <Group justify="flex-end">
+          <Button color="gray" onClick={() => setDismiss7702Check(true)}>
+            Continue Anyway
+          </Button>
+        </Group>
+      </Stack>
+    </Alert>
   ) : (
     <Stack>
       <Stepper active={active}>

--- a/app/hooks/useSupports7702.ts
+++ b/app/hooks/useSupports7702.ts
@@ -1,0 +1,55 @@
+import { useQuery } from "@tanstack/react-query";
+import { bytesToHex, getAddress } from "viem";
+import {
+  generatePrivateKey,
+  privateKeyToAccount,
+  signAuthorization,
+} from "viem/accounts";
+import { call } from "viem/actions";
+import { useClient } from "wagmi";
+
+const echo = {
+  address: getAddress(`0x${"ee".repeat(20)}`),
+  code: "0x363d3d37363df3",
+} as const;
+
+function useSupports7702() {
+  const client = useClient();
+
+  return useQuery({
+    queryKey: ["chain:support:eip-7702", `${client?.chain?.id}`],
+    queryFn: async () => {
+      if (!client) {
+        return null;
+      }
+
+      const privateKey = generatePrivateKey();
+      const { address } = privateKeyToAccount(privateKey);
+      const authorization = await signAuthorization({
+        privateKey,
+        chainId: 0,
+        address: echo.address,
+        nonce: 0,
+      });
+
+      const message = bytesToHex(
+        new TextEncoder().encode("The wise speak only of what they know."),
+      );
+
+      try {
+        const { data: response } = await call(client, {
+          to: address,
+          data: message,
+          authorizationList: [authorization],
+          stateOverride: [echo],
+        });
+        return response === message;
+      } catch {
+        return false;
+      }
+    },
+    enabled: !!client,
+  });
+}
+
+export { useSupports7702 };


### PR DESCRIPTION
This PR adds an EIP-7702 support check and warning message if support cannot be detected. The support works by doing an `eth_call` with a delegation from a random private key to a state-overriden contract. This may cause false-negatives (in case the RPC node that is connected to does not support `eth_call` state overrides for example), so a "continue anyway" button is included.

<img width="1122" height="729" alt="image" src="https://github.com/user-attachments/assets/5837bb6d-103d-4115-9f22-0cb8f89a93f1" />
