### PR TITLE
Target EVM Paris

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -10,7 +10,7 @@ const config: HardhatUserConfig = {
   solidity: {
     version: "0.8.29",
     settings: {
-      evmVersion: "prague",
+      evmVersion: "paris",
       optimizer: {
         enabled: true,
         runs: 1,


### PR DESCRIPTION
This ensures the Bootstrap contract does not use `PUSH0` opcode for better chain support. In particular, this should allow us to support Linea (which does not have `PUSH0` opcode).

Note that the CREATE2 factory itself already doesn't use `PUSH0` for improved portability across chains, so it just makes sense for the bootstrap contract to do the same!