### PR TITLE
Sticky Burner Funds Computation Errors

### DIFF
--- a/app/components/Deploy.tsx
+++ b/app/components/Deploy.tsx
@@ -203,7 +203,7 @@ function Deploy() {
 function Connected() {
   const bootstrap = useBootstrapContract();
   const transaction = useDeployFactoryTransaction({ bootstrap });
-  const funding = useBurnerMissingFunds({ transaction });
+  const [funding, fundingError] = useBurnerMissingFunds({ transaction });
   const factory = useFactoryDeployed();
 
   const isPending =
@@ -252,20 +252,22 @@ function Connected() {
           <Deployed />
         </Stepper.Completed>
       </Stepper>
-      {funding.error && (
-        <Notification
-          color="red"
-          title="Error fetching burner account information"
-        >
-          {funding.error.message}
-        </Notification>
-      )}
       {factory.error && (
         <Notification
           color="red"
           title="Error fetching CREATE2 factory deployment status"
+          withCloseButton={false}
         >
           {factory.error.message}
+        </Notification>
+      )}
+      {fundingError && (
+        <Notification
+          color="red"
+          title="Error fetching burner account information"
+          withCloseButton={false}
+        >
+          {fundingError.message}
         </Notification>
       )}
     </Stack>

--- a/app/hooks/useBurnerMissingFunds.ts
+++ b/app/hooks/useBurnerMissingFunds.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
 import { formatTransactionRequest, type TransactionRequestEIP7702 } from "viem";
 import { estimateGas, getBalance, getGasPrice } from "viem/actions";
 import { useClient } from "wagmi";
@@ -18,7 +19,8 @@ function useBurnerMissingFunds({
   const client = useClient();
   const burner = useBurnerAccount();
 
-  return useQuery({
+  const [stickyError, setStickyError] = useState<Error | null>(null);
+  const query = useQuery({
     queryKey: [
       "burner:missing-funds",
       burner.address,
@@ -52,6 +54,16 @@ function useBurnerMissingFunds({
     staleTime: 1000,
     refetchInterval: 1000,
   });
+
+  useEffect(() => {
+    if (query.status === "success") {
+      setStickyError(null);
+    } else if (query.status === "error") {
+      setStickyError(query.error);
+    }
+  }, [query.status, query.error]);
+
+  return [query, stickyError] as const;
 }
 
 export { useBurnerMissingFunds };


### PR DESCRIPTION
Computing missing burner funds is a refetching operation, and because of how `useQuery` works, the error gets cleared in between refetches. On chains where the burner balance and missing funds fails repeatedly, this causes the error message to "flash" which isn't great, and makes it hard to tell that there is a persistent error in the first place.

Make the error sticky for this refetching query.