### PR TITLE
Use New `erc-7955` Org for Packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "@safe-research/erc-7955-monorepo",
+  "name": "@erc-7955/monorepo",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@safe-research/erc-7955-monorepo",
+      "name": "@erc-7955/monorepo",
       "license": "GPL-3.0-only",
       "workspaces": [
         "packages/*"
@@ -894,6 +894,14 @@
       "peerDependencies": {
         "@noble/ciphers": "^1.0.0"
       }
+    },
+    "node_modules/@erc-7955/app": {
+      "resolved": "packages/app",
+      "link": true
+    },
+    "node_modules/@erc-7955/core": {
+      "resolved": "packages/core",
+      "link": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.9",
@@ -4210,10 +4218,6 @@
     },
     "node_modules/@safe-research/erc-7955": {
       "resolved": "packages/core",
-      "link": true
-    },
-    "node_modules/@safe-research/erc-7955-app": {
-      "resolved": "packages/app",
       "link": true
     },
     "node_modules/@scure/base": {
@@ -9165,12 +9169,11 @@
       }
     },
     "packages/app": {
-      "name": "@safe-research/erc-7955-app",
-      "version": "1.0.0",
+      "name": "@erc-7955/app",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@mantine/core": "^8.2.8",
-        "@safe-research/erc-7955": "^1.0.0",
+        "@safe-research/erc-7955": "=1.0.0",
         "@tanstack/react-query": "^5.85.9",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -9185,7 +9188,7 @@
       }
     },
     "packages/core": {
-      "name": "@safe-research/erc-7955",
+      "name": "@erc-7955/core",
       "version": "1.0.0",
       "license": "GPL-3.0-only",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "@safe-research/erc-7955-monorepo",
+  "name": "@erc-7955/monorepo",
+  "private": true,
   "description": "ERC-7955: Permissionless CREATE2 Factory",
   "author": "Safe Research <research@safe.global>",
   "license": "GPL-3.0-only",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@safe-research/erc-7955-app",
-  "version": "1.0.0",
+  "name": "@erc-7955/app",
+  "private": true,
   "description": "ERC-7955: Permissionless CREATE2 Factory App",
   "type": "module",
   "scripts": {
@@ -11,7 +11,7 @@
   "license": "GPL-3.0-only",
   "dependencies": {
     "@mantine/core": "^8.2.8",
-    "@safe-research/erc-7955": "^1.0.0",
+    "@safe-research/erc-7955": "=1.0.0",
     "@tanstack/react-query": "^5.85.9",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@safe-research/erc-7955",
+  "name": "@erc-7955/core",
   "version": "1.0.0",
   "description": "ERC-7955: Permissionless CREATE2 Factory",
   "type": "module",


### PR DESCRIPTION
This PR changes the packages to use the `erc-7955` org in preparation for the `core` package release.