### PR TITLE
Improve EIP-7702 Detection

### DIFF
--- a/packages/app/status/src/lib/chain.ts
+++ b/packages/app/status/src/lib/chain.ts
@@ -1,12 +1,15 @@
 import { factory } from "@safe-research/erc-7955";
 import {
+  type Address,
   bytesToHex,
   type CallErrorType,
   type Client,
+  concat,
   createClient,
   defineChain,
   fallback,
   getAddress,
+  getContractAddress,
   http,
 } from "viem";
 import {
@@ -29,7 +32,7 @@ async function detectStatus({ chainId, rpc }: Chain): Promise<Status> {
     if (await isErc7955Deployed({ client })) {
       return "deployed";
     }
-    if (await isErc7702Supported({ client })) {
+    if (await isEip7702Supported({ client })) {
       return "supported";
     }
     return "notsupported";
@@ -70,38 +73,33 @@ async function isErc7955Deployed({ client }: { client: Client }) {
   return bytecode === factory.runtimeCode;
 }
 
-const echoRequest = (async () => {
-  const echo = {
-    address: getAddress(`0x${"ee".repeat(20)}`),
-    code: "0x363d3d37363df3",
-  } as const;
-
-  const privateKey = generatePrivateKey();
-  const { address } = privateKeyToAccount(privateKey);
-  const authorization = await signAuthorization({
-    privateKey,
-    chainId: 0,
-    address: echo.address,
-    nonce: 0,
-  });
-
-  const message = bytesToHex(
-    new TextEncoder().encode("The wise speak only of what they know."),
+async function isEip7702Supported({ client }: { client: Client }) {
+  // We have two kinds of `eth_call`s that we can do to detect EIP-7702 support
+  // on a chain:
+  // 1. Call with a delegation to a known contract (we use CREATE2 deployers
+  //    as they are very widely available on chains)
+  // 2. Call with a delegation to a state override
+  //
+  // We prefer 1, as not all RPCs support state overrides.
+  const calls = await Promise.all(
+    [ERC7702_CALLS.safeSingletonFactory, ERC7702_CALLS.nicksDeployer].map(
+      async (promise) => {
+        const call = await promise;
+        const bytecode = await getCode(
+          client,
+          call.request.authorizationList[0],
+        );
+        const available = bytecode !== undefined;
+        return available ? call : null;
+      },
+    ),
   );
+  const { request, response } =
+    calls.find((call) => !!call) ?? (await ERC7702_CALLS.echo);
 
-  return {
-    to: address,
-    data: message,
-    authorizationList: [authorization],
-    stateOverride: [echo],
-  };
-})();
-
-async function isErc7702Supported({ client }: { client: Client }) {
   try {
-    const request = await echoRequest;
-    const response = await call(client, request);
-    return response.data === request.data;
+    const { data } = await call(client, request);
+    return data === response.data;
   } catch (e) {
     const err = e as CallErrorType;
     switch (err.cause.name) {
@@ -115,6 +113,88 @@ async function isErc7702Supported({ client }: { client: Client }) {
     }
   }
 }
+
+async function eip7702RandomAuthorization(contract: { address: Address }) {
+  const privateKey = generatePrivateKey();
+  const { address } = privateKeyToAccount(privateKey);
+  const authorization = await signAuthorization({
+    privateKey,
+    chainId: 0,
+    address: contract.address,
+    nonce: 0,
+  });
+
+  return { address, authorization };
+}
+
+async function eip7702Create2FactoryCall(factory: { address: Address }) {
+  const { address, authorization } = await eip7702RandomAuthorization(factory);
+
+  const salt = `0x${"5afe".repeat(16)}` as const;
+  // For the bytecode, we just prefix it with `0x00`, which is the opcode for
+  // `STOP` and will cause this init code to deploy contracts with empty
+  // runtime code. The extra bytes after the `STOP` are just there for adding
+  // another easter egg to the project :P.
+  const bytecode = bytesToHex(
+    new TextEncoder().encode(
+      "\0May the wind under the wings bear you where the sun sails and the moon walks.",
+    ),
+  );
+  const create = getContractAddress({
+    opcode: "CREATE2",
+    from: address,
+    salt,
+    bytecode,
+  });
+
+  return {
+    request: {
+      to: address,
+      data: concat([salt, bytecode]),
+      authorizationList: [authorization],
+    },
+    response: {
+      data: create.toLowerCase(),
+    },
+  };
+}
+
+async function eip7702EchoCall() {
+  const echo = {
+    address: getAddress(`0x${"ee".repeat(20)}`),
+    code: "0x363d3d37363df3",
+  } as const;
+
+  const { address, authorization } = await eip7702RandomAuthorization(echo);
+
+  const message = bytesToHex(
+    new TextEncoder().encode("I am Gandalf, and Gandalf means me."),
+  );
+
+  return {
+    request: {
+      to: address,
+      data: message,
+      authorizationList: [authorization],
+      stateOverride: [echo],
+    },
+    response: {
+      data: message,
+    },
+  };
+}
+
+// Pre-bake some calls for detecting EIP-7702 support as they get used by all
+// chains and we don't want to compute signatures and hashes thousands of times.
+const ERC7702_CALLS = {
+  safeSingletonFactory: eip7702Create2FactoryCall({
+    address: "0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7",
+  }),
+  nicksDeployer: eip7702Create2FactoryCall({
+    address: "0x4e59b44847b379578588920cA78FbF26c0B4956C",
+  }),
+  echo: eip7702EchoCall(),
+};
 
 export type { Chain, Status };
 export { detectStatus };

--- a/packages/app/status/src/lib/chain.ts
+++ b/packages/app/status/src/lib/chain.ts
@@ -74,29 +74,7 @@ async function isErc7955Deployed({ client }: { client: Client }) {
 }
 
 async function isEip7702Supported({ client }: { client: Client }) {
-  // We have two kinds of `eth_call`s that we can do to detect EIP-7702 support
-  // on a chain:
-  // 1. Call with a delegation to a known contract (we use CREATE2 deployers
-  //    as they are very widely available on chains)
-  // 2. Call with a delegation to a state override
-  //
-  // We prefer 1, as not all RPCs support state overrides.
-  const calls = await Promise.all(
-    [ERC7702_CALLS.safeSingletonFactory, ERC7702_CALLS.nicksDeployer].map(
-      async (promise) => {
-        const call = await promise;
-        const bytecode = await getCode(
-          client,
-          call.request.authorizationList[0],
-        );
-        const available = bytecode !== undefined;
-        return available ? call : null;
-      },
-    ),
-  );
-  const { request, response } =
-    calls.find((call) => !!call) ?? (await ERC7702_CALLS.echo);
-
+  const { request, response } = await eip7702PreferredCall({ client });
   try {
     const { data } = await call(client, request);
     return data === response.data;
@@ -112,6 +90,35 @@ async function isEip7702Supported({ client }: { client: Client }) {
         return false;
     }
   }
+}
+
+async function eip7702PreferredCall({ client }: { client: Client }) {
+  // We have two kinds of `eth_call`s that we can do to detect EIP-7702 support
+  // on a chain:
+  // 1. Call with a delegation to a known contract (we use CREATE2 deployers
+  //    as they are very widely available on chains)
+  // 2. Call with a delegation to a state override
+  //
+  // We prefer 1, as not all RPCs support state overrides. Try to find a
+  // deployed contract that we can use.
+  const contractCalls = await Promise.all([
+    ERC7702_CALLS.safeSingletonFactory,
+    ERC7702_CALLS.nicksDeployer,
+  ]);
+  const contractAddresses = contractCalls.map(
+    ({ request }) => request.authorizationList[0],
+  );
+  const contractCodes = await Promise.all(
+    contractAddresses.map((address) => getCode(client, address)),
+  );
+  for (let i = 0; i < contractCalls.length; i++) {
+    if (contractCodes[i] !== undefined) {
+      return contractCalls[i];
+    }
+  }
+
+  // None of the contracts are deployed, so fall back to using a state override.
+  return await ERC7702_CALLS.echo;
 }
 
 async function eip7702RandomAuthorization(contract: { address: Address }) {


### PR DESCRIPTION
We cast a wide net with our EIP-7702 detection by first trying to delegate to a known contract before falling back to state overrides. This is because not all RPCs support state overrides.

This makes it so that 4 additional chains are detected as "supported" compared to before.