### PR TITLE
Build Status Page Without `erc-7955` Prefix

### DIFF
--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -4,7 +4,14 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [react()],
-  base: "/erc-7955/",
+  build: {
+    rollupOptions: {
+      input: {
+        index: path.resolve(__dirname, "index.html"),
+        status: path.resolve(__dirname, "status/index.html"),
+      },
+    },
+  },
   resolve: {
     alias: {
       "$/": `${path.resolve(__dirname, "src")}/`,


### PR DESCRIPTION
This PR adds the `status` page as an additional rollup input so that it gets bundled in the `vite build` output.

Additionally, we remove the `/erc-7955/` base path, as the dapp is to be hosted on `erc-7955.safe.dev`.